### PR TITLE
Bugfix and enhancements

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -45,6 +45,10 @@ class Command:
         self.active = not self.active
         msg_status('Colored Indent: '+('on' if self.active else 'off'))
 
+        self.apply_settings()
+
+    def apply_settings(self):
+
         for h in ed_handles():
             e = Editor(h)
             if self.active:
@@ -52,7 +56,6 @@ class Command:
                     self.work(e)
             else:
                 e.attr(MARKERS_DELETE_BY_TAG, tag=MARKTAG)
-
 
     def on_start(self, ed_self):
 
@@ -65,7 +68,7 @@ class Command:
         if state==APPSTATE_THEME_SYNTAX:
             _theme = app_proc(PROC_THEME_SYNTAX_DICT_GET, '')
             self.update_colors()
-            self.work(ed_self)
+            self.apply_settings()
 
     def get_color(self, n):
 

--- a/install.inf
+++ b/install.inf
@@ -15,6 +15,11 @@ section=commands
 caption=Colored Indent\Toggle active
 method=toggle
 
+[item3]
+section=commands
+caption=Colored Indent\Reload config
+method=reload_config
+
 [item10]
 section=commands
 caption=Colored Indent\Config

--- a/opt.py
+++ b/opt.py
@@ -1,8 +1,10 @@
 DEF_SET = 'SectionBG1,SectionBG2,SectionBG3,SectionBG4'
 DEF_ERROR = 'LightBG2'
 DEF_LEXERS = 'Python'
-            
+DEF_ACTIVE = '1'
+
 color_error = 0xff
 color_set = (0xff00, 0xffff)
 lexers = ''
 max_lines = 2000
+active = True

--- a/readme/history.txt
+++ b/readme/history.txt
@@ -1,6 +1,12 @@
 
+2019.11.17
+- fix: when colors of theme syntax items are changed, only indent colors of document in currently active tab get updated.
+- add: save active state of plugin in plugin settings file and restore it at next run of CudaText.
+- add: add menu entry "Reload config" to plugin's submenu in "Plugins" menu.
+
 2019.11.14
 - fix: avoid deleted CudaText API
+- add: handle theme change
 
 2019.04.25
 + add: command "Toggle active" must apply to all opened file tabs

--- a/readme/readme.txt
+++ b/readme/readme.txt
@@ -11,8 +11,12 @@ plugin has config file, to open it: "Options / Settings-plugins / Colored Indent
 - "color_set": ","-separated list of syntax-theme elements, from which background colors are taken.
 - "color_error": syntax-theme element, from which error color is taken.
 - "max_lines": maximal count of lines in document, when plugin is active.
+- "active": persists activation state of plugin to restore it in next session.
+
+plugin adds a menu entry to manually reload its config file: "Plugins / Colored Indent / Reload config".
 
 plugin works on events: after file opened; after text is changed and short pause is passed.
 
 author: Alexey Torgashin (CudaText)
+enhancements: Andreas Heim (dinkumoil)
 license: MIT


### PR DESCRIPTION
* Fix: When colors of theme syntax items are changed, only indent colors of document in currently active tab get updated.
* Enhancement: Save active state of plugin in plugin settings file and restore it at next run of _CudaText_.
* Enhancement: Add menu entry `Reload config` to plugin's submenu in `Plugins` menu.
